### PR TITLE
Add option to parse not-quite-SPDX expressions used by crates-io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [PR#19](https://github.com/EmbarkStudios/spdx/pull/19) Added `ParseMode` enum, which has a `Lax` variant that allows certain invvalid license identifiers found in some crates on crates.io, as well as the invalid `/` expression separator. Thanks [@kornel](https://github.com/kornelski)!
 
 ## [0.3.0] - 2019-12-14
 ### Added
@@ -37,7 +39,7 @@ as all of the other ones. See [this issue](https://github.com/EmbarkStudios/carg
 
 ## [0.2.1] - 2019-10-21
 ### Added
-- [#9](https://github.com/EmbarkStudios/spdx/pull/9) Added a flag for determining if a license is considered [copyleft](https://en.wikipedia.org/wiki/Copyleft). Thanks [@kain88-de](https://github.com/kain88-de)
+- [#9](https://github.com/EmbarkStudios/spdx/pull/9) Added a flag for determining if a license is considered [copyleft](https://en.wikipedia.org/wiki/Copyleft). Thanks [@kain88-de](https://github.com/kain88-de)!
 
 ## [0.2.0] - 2019-10-03
 ### Added

--- a/src/expression/parser.rs
+++ b/src/expression/parser.rs
@@ -2,8 +2,7 @@ use crate::{
     error::{ParseError, Reason},
     expression::{ExprNode, Expression, ExpressionReq, Operator},
     lexer::{Lexer, Token},
-    LicenseItem, LicenseReq,
-    ParseMode,
+    LicenseItem, LicenseReq, ParseMode,
 };
 use smallvec::SmallVec;
 

--- a/src/identifiers.rs
+++ b/src/identifiers.rs
@@ -1268,6 +1268,39 @@ pub const LICENSES: &[(&str, &str, u8)] = &[
     ),
 ];
 
+/// These are matched as case-insensitive substrings. Order is important.
+pub(crate) const IMPRECISE_NAMES: &[(&str, &str)] = &[
+    ("agplv3", "AGPL-3.0"),
+    ("agpl", "AGPL-3.0"),
+    ("apache 2.0", "Apache-2.0"),
+    ("apache-2", "Apache-2.0"),
+    ("apache2", "Apache-2.0"),
+    ("apache", "Apache-2.0"),
+    ("asl2.0", "Apache-2.0"),
+    ("bsd 2-clause", "BSD-2-Clause"),
+    ("bsd-2clause", "BSD-2-Clause"),
+    ("bsd3", "BSD-3-Clause"),
+    ("bsd", "BSD-2-Clause"),
+    ("cc0", "CC0-1.0"),
+    ("gnu gpl v2", "GPL-3.0"),
+    ("gnu gpl v3", "GPL-3.0"),
+    ("gpl v2", "GPL-2.0"),
+    ("gpl v3", "GPL-3.0"),
+    ("gpl-2.0", "GPL-2.0"),
+    ("gpl-3.0", "GPL-3.0"),
+    ("gpl2", "GPL-2.0"),
+    ("gpl3", "GPL-3.0"),
+    ("gplv2", "GPL-2.0"),
+    ("gplv3", "GPL-3.0"),
+    ("gpl", "GPL-2.0"),
+    ("lgpl", "LGPL-2.0"),
+    ("mit", "MIT"),
+    ("mpl2", "MPL-2.0"),
+    ("mpl", "MPL-2.0"),
+    ("simplified bsd license", "BSD-2-Clause"),
+    ("zlib", "Zlib"),
+];
+
 pub const EXCEPTIONS: &[(&str, u8)] = &[
     ("389-exception", 0),
     ("Autoconf-exception-2.0", 0),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{ParseError, Reason},
     ExceptionId, LicenseId,
+    ParseMode,
 };
 use lazy_static::lazy_static;
 
@@ -66,6 +67,7 @@ pub struct Lexer<'a> {
     inner: &'a str,
     original: &'a str,
     offset: usize,
+    lax: bool,
 }
 
 impl<'a> Lexer<'a> {
@@ -75,6 +77,20 @@ impl<'a> Lexer<'a> {
             inner: text,
             original: text,
             offset: 0,
+            lax: false,
+        }
+    }
+
+    /// Creates a Lexer over a license expression
+    ///
+    /// With `ParseMode::Lax` it allows non-conforming syntax
+    /// used in crates-io crates.
+    pub fn new_mode(text: &'a str, mode: ParseMode) -> Self {
+        Self {
+            inner: text,
+            original: text,
+            offset: 0,
+            lax: mode == ParseMode::Lax,
         }
     }
 }
@@ -110,21 +126,27 @@ impl<'a> Iterator for Lexer<'a> {
         self.inner = &self.inner[non_whitespace_index..];
         self.offset += non_whitespace_index;
 
+        fn ok_token<'a>(token: Token) -> Option<Result<(Token, usize), ParseError<'a>>> {
+            let len = token.len();
+            Some(Ok((token, len)))
+        }
+
         match self.inner.chars().next() {
             None => None,
             // From SPDX 2.1 spec
             // There MUST NOT be whitespace between a license-id and any following "+".
-            Some('+') => Some(if non_whitespace_index != 0 {
-                Err(ParseError {
+            Some('+') => if non_whitespace_index != 0 {
+                Some(Err(ParseError {
                     original: self.original,
                     span: self.offset - non_whitespace_index..self.offset,
                     reason: Reason::SeparatedPlus,
-                })
+                }))
             } else {
-                Ok(Token::Plus)
-            }),
-            Some('(') => Some(Ok(Token::OpenParen)),
-            Some(')') => Some(Ok(Token::CloseParen)),
+                ok_token(Token::Plus)
+            },
+            Some('(') => ok_token(Token::OpenParen),
+            Some(')') => ok_token(Token::CloseParen),
+            Some('/') if self.lax => Some(Ok((Token::Or, 1))),
             _ => match TEXTTOKEN.find(self.inner) {
                 None => Some(Err(ParseError {
                     original: self.original,
@@ -133,25 +155,31 @@ impl<'a> Iterator for Lexer<'a> {
                 })),
                 Some(m) => {
                     if m.as_str() == "WITH" {
-                        Some(Ok(Token::With))
+                        ok_token(Token::With)
                     } else if m.as_str() == "AND" {
-                        Some(Ok(Token::And))
+                        ok_token(Token::And)
                     } else if m.as_str() == "OR" {
-                        Some(Ok(Token::Or))
+                        ok_token(Token::Or)
+                    } else if self.lax && m.as_str() == "and" {
+                        ok_token(Token::And)
+                    } else if self.lax && m.as_str() == "or" {
+                        ok_token(Token::Or)
                     } else if let Some(lic_id) = crate::license_id(&m.as_str()) {
-                        Some(Ok(Token::SPDX(lic_id)))
+                        ok_token(Token::SPDX(lic_id))
                     } else if let Some(exc_id) = crate::exception_id(&m.as_str()) {
-                        Some(Ok(Token::Exception(exc_id)))
+                        ok_token(Token::Exception(exc_id))
                     } else if let Some(c) = DOCREFLICREF.captures(m.as_str()) {
-                        Some(Ok(Token::LicenseRef {
+                        ok_token(Token::LicenseRef {
                             doc_ref: Some(c.get(1).unwrap().as_str()),
                             lic_ref: c.get(2).unwrap().as_str(),
-                        }))
+                        })
                     } else if let Some(c) = LICREF.captures(m.as_str()) {
-                        Some(Ok(Token::LicenseRef {
+                        ok_token(Token::LicenseRef {
                             doc_ref: None,
                             lic_ref: c.get(1).unwrap().as_str(),
-                        }))
+                        })
+                    } else if let Some((lic_id, token_len)) = if self.lax {crate::imprecise_license_id(self.inner)} else {None} {
+                        Some(Ok((Token::SPDX(lic_id), token_len)))
                     } else {
                         Some(Err(ParseError {
                             original: self.original,
@@ -163,8 +191,7 @@ impl<'a> Iterator for Lexer<'a> {
             },
         }
         .map(|res| {
-            res.map(|tok| {
-                let len = tok.len();
+            res.map(|(tok, len)| {
                 let start = self.offset;
                 self.inner = &self.inner[len..];
                 self.offset += len;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,7 +1,6 @@
 use crate::{
     error::{ParseError, Reason},
-    ExceptionId, LicenseId,
-    ParseMode,
+    ExceptionId, LicenseId, ParseMode,
 };
 use lazy_static::lazy_static;
 
@@ -135,15 +134,17 @@ impl<'a> Iterator for Lexer<'a> {
             None => None,
             // From SPDX 2.1 spec
             // There MUST NOT be whitespace between a license-id and any following "+".
-            Some('+') => if non_whitespace_index != 0 {
-                Some(Err(ParseError {
-                    original: self.original,
-                    span: self.offset - non_whitespace_index..self.offset,
-                    reason: Reason::SeparatedPlus,
-                }))
-            } else {
-                ok_token(Token::Plus)
-            },
+            Some('+') => {
+                if non_whitespace_index != 0 {
+                    Some(Err(ParseError {
+                        original: self.original,
+                        span: self.offset - non_whitespace_index..self.offset,
+                        reason: Reason::SeparatedPlus,
+                    }))
+                } else {
+                    ok_token(Token::Plus)
+                }
+            }
             Some('(') => ok_token(Token::OpenParen),
             Some(')') => ok_token(Token::CloseParen),
             Some('/') if self.lax => Some(Ok((Token::Or, 1))),
@@ -178,7 +179,11 @@ impl<'a> Iterator for Lexer<'a> {
                             doc_ref: None,
                             lic_ref: c.get(1).unwrap().as_str(),
                         })
-                    } else if let Some((lic_id, token_len)) = if self.lax {crate::imprecise_license_id(self.inner)} else {None} {
+                    } else if let Some((lic_id, token_len)) = if self.lax {
+                        crate::imprecise_license_id(self.inner)
+                    } else {
+                        None
+                    } {
                         Some(Ok((Token::SPDX(lic_id), token_len)))
                     } else {
                         Some(Err(ParseError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ pub(crate) fn imprecise_license_id(name: &str) -> Option<(LicenseId, usize)> {
                 if name.as_bytes().get(len).copied() == Some(b'+') {
                     len += 1;
                 }
-                return license_id(correct_name).map(|lic| (lic, len))
+                return license_id(correct_name).map(|lic| (lic, len));
             }
         }
     }

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -123,6 +123,18 @@ fn fails_with_slash() {
 }
 
 #[test]
+fn lax_takes_slash() {
+    let lexed: Vec<_> = Lexer::new_mode("MIT/Apache", spdx::ParseMode::Lax).map(|r| r.map(|lt| lt.token).unwrap()).collect();
+    assert_eq!(&lexed, &[lic_tok!("MIT"), Token::Or, lic_tok!("Apache-2.0")]);
+}
+
+#[test]
+fn fixes_license_names() {
+    let lexed: Vec<_> = Lexer::new_mode("gpl v2 / bsd 2-clause", spdx::ParseMode::Lax).map(|r| r.map(|lt| lt.token).unwrap()).collect();
+    assert_eq!(&lexed, &[lic_tok!("GPL-2.0"), Token::Or, lic_tok!("BSD-2-Clause")]);
+}
+
+#[test]
 fn lexes_complex() {
     let complex = "(Apache-2.0 WITH LLVM-exception) OR Apache-2.0 OR MIT";
 

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -124,14 +124,24 @@ fn fails_with_slash() {
 
 #[test]
 fn lax_takes_slash() {
-    let lexed: Vec<_> = Lexer::new_mode("MIT/Apache", spdx::ParseMode::Lax).map(|r| r.map(|lt| lt.token).unwrap()).collect();
-    assert_eq!(&lexed, &[lic_tok!("MIT"), Token::Or, lic_tok!("Apache-2.0")]);
+    let lexed: Vec<_> = Lexer::new_mode("MIT/Apache", spdx::ParseMode::Lax)
+        .map(|r| r.map(|lt| lt.token).unwrap())
+        .collect();
+    assert_eq!(
+        &lexed,
+        &[lic_tok!("MIT"), Token::Or, lic_tok!("Apache-2.0")]
+    );
 }
 
 #[test]
 fn fixes_license_names() {
-    let lexed: Vec<_> = Lexer::new_mode("gpl v2 / bsd 2-clause", spdx::ParseMode::Lax).map(|r| r.map(|lt| lt.token).unwrap()).collect();
-    assert_eq!(&lexed, &[lic_tok!("GPL-2.0"), Token::Or, lic_tok!("BSD-2-Clause")]);
+    let lexed: Vec<_> = Lexer::new_mode("gpl v2 / bsd 2-clause", spdx::ParseMode::Lax)
+        .map(|r| r.map(|lt| lt.token).unwrap())
+        .collect();
+    assert_eq!(
+        &lexed,
+        &[lic_tok!("GPL-2.0"), Token::Or, lic_tok!("BSD-2-Clause")]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds support for invalid licenses used in crates-io crates. Fixes #18 

<details>
<pre>
AGPL
AGPL-3.0+
AGPL-3.0/GPL-3.0/MIT/Apache-2.0
AGPLv3
AGPLv3/ASL2.0
AML/Apache-2.0
Apache 2.0
Apache-2.0 / MIT
Apache-2.0 / MIT / MPL-2.0
Apache-2.0/BSD-3-Clause-Clear/MIT
Apache-2.0/GPL-2.0+
Apache-2.0/GPL-3.0
Apache-2.0/ISC/MIT
Apache-2.0/MIT
Apache-2.0/MIT/BSL-1.0/CC0-1.0
Apache-2.0/MIT/Unlicense
Apache-2.0/PostgreSQL
Apache2/MIT
BSD
BSD 2-Clause
BSD-2Clause
BSD-3-Clause-Clear/Apache-2.0
BSD-3-Clause/MIT
BSD3
BSL-1.0/Apache-2.0
CC-BY-SA-4.0/MIT
CC0
FTL / GPL-2.0
GNU GPL v3
GPL
GPL v2
GPL-2.0+
GPL-2.0+ AND LGPL-2.1+ AND MPL-1.1
GPL-2.0/GPL-3.0/Apache-2.0/MIT
GPL-3.0 / MPL-2.0
GPL-3.0+
GPL-3.0+ AND BSD-3-Clause
GPL-3.0+ OR BSD-3-Clause
GPL-3.0+/BSD-3-Clause
GPL-3.0/GFDL-1.3
GPL3
GPLv2+
GPLv3
ISC/Apache-2.0
ISC/MIT/Apache-2.0
LGPL
LGPL-2.0+
LGPL-2.1+
LGPL-2.1/BSD-2-Clause
LGPL-2.1/LGPL-3.0
LGPL-3.0+
LGPL-3.0/GPL-2.0/GPL-3.0
MIT / Apache-2.0
MIT / BSL-1.0
MIT OR Apache-2
MIT OR GPL-3.0+
MIT or Apache-2.0
MIT/AGPL-1.0
MIT/APSL-2.0
MIT/Apache-1.0
MIT/Apache-2.0
MIT/Apache-2.0 AND BSD-2-Clause
MIT/Apache-2.0/BSD-3-Clause
MIT/Apache-2.0/BSL-1.0
MIT/Apache-2.0/CC0-1.0
MIT/Apache-2.0/ISC
MIT/Apache-2.0/LGPL-2.1
MIT/Apache-2.0/NCSA
MIT/Apache-2.0/Unlicense
MIT/Apache-2.0/Unlicense/WTFPL
MIT/Apache2
MIT/BSD-2-Clause
MIT/BSD-3-Clause
MIT/BSL-1.0
MIT/GPL-3.0
MIT/ISC
MIT/LGPL-2.1
MIT/LGPL-3.0
MIT/NCSA
MIT/Unlicense
MIT/X11
MIT/X11 OR Apache-2.0
MIT/Zlib
MPL-1.1/GPL-2.0/LGPL-2.1
MPL-2.0+/LGPL-3.0+
MPL-2.0/MIT/Apache-2.0
MPL2
Mit
OSL-3.0/AGPL-3.0-or-later
Simplified BSD License
UPL-1.0/Apache-2.0
Unlicense/Apache-2.0
Unlicense/MIT
Unlicense/MPL-1.1/MIT
Zlib / MIT / BSL-1.0
Zlib/MIT
apache
gpl-3.0
zlib
</pre>
</details>