### PR TITLE
Remove regex dependency by manually parsing LicenceRef/DocumentRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,8 @@ include = [
 ]
 
 [dependencies]
-lazy_static = "1.4"
 smallvec = "1.6"
 
-[dependencies.regex]
-version = "1.4"
-default-features = false
-features = ["std"]
 
 [dev-dependencies]
 difference = "2.0"


### PR DESCRIPTION
Hi

This PR removes the regex and lazy_static dependencies - main reason is to improve compile times, in my specific case I have a project that uses pcre2 for regex so it seemed unfortunate to have two regex crates included when using this one as well.

I'm happy to make any changes if requested.

Thanks