### PR TITLE
Add NOASSERTION

### DIFF
--- a/src/identifiers.rs
+++ b/src/identifiers.rs
@@ -1165,6 +1165,7 @@ pub const LICENSES: &[(&str, &str, u8)] = &[
         0x0,
     ),
     ("NLPL", r#"No Limit Public License"#, 0x0),
+    ("NOASSERTION", r#"NOASSERTION"#, 0x0),
     ("NOSL", r#"Netizen Open Source License"#, IS_FSF_LIBRE),
     (
         "NPL-1.0",

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -247,3 +247,11 @@ fn gfdl() {
         false => |req| exact!(req, "GFDL-1.3-invariants"),
     ]);
 }
+
+#[test]
+fn noassertion() {
+    check!("NOASSERTION AND OpenSSL" => [
+        true && false => |req| exact!(req, "NOASSERTION") || exact!(req, "MIT"),
+        true && true => |req| exact!(req, "NOASSERTION") || exact!(req, "OpenSSL"),
+    ]);
+}

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -210,6 +210,11 @@ pub const IS_GNU: u8 = 0x10;
                 }
             }
 
+            let name = "NOASSERTION".to_owned();
+            // Add NOASSERTION, which is not yet? part of the SPDX spec
+            // https://github.com/spdx/spdx-spec/issues/50
+            v.push(("NOASSERTION".to_owned(), &name, "0x0".to_owned()));
+
             v.sort_by(|a, b| a.0.cmp(&b.0));
 
             let lic_list_ver = get(&json, "licenseListVersion")?;


### PR DESCRIPTION
As noted [here](https://github.com/spdx/spdx-spec/issues/50#issuecomment-456264240), clearlydefined liberally uses `NOASSERTION` during its analysis, and it looks like it's possible `NOASSERTION` could become a part of the SPDX spec, so until that gets resolved we just add it as another license identifier for simplicity.