### PR TITLE
Cleanup (clippy warnings)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -89,10 +89,10 @@ impl fmt::Display for Reason {
                         f.write_fmt(format_args!("{}`{}`", if i > 0 { ", " } else { "" }, exp))?;
                     }
                     f.write_str(" here")
-                } else if !expected.is_empty() {
-                    f.write_fmt(format_args!("expected a `{}` here", expected[0]))
-                } else {
+                } else if expected.is_empty() {
                     f.write_str("the term was not expected here")
+                } else {
+                    f.write_fmt(format_args!("expected a `{}` here", expected[0]))
                 }
             }
             Self::SeparatedPlus => f.write_str("`+` must not follow whitespace"),

--- a/src/expression/minimize.rs
+++ b/src/expression/minimize.rs
@@ -120,6 +120,6 @@ impl super::Expression {
         }
 
         // This should be impossible, but would rather not panic
-        Ok(found_set.into_iter().map(|lic| lic.into_req()).collect())
+        Ok(found_set.into_iter().map(Licensee::into_req).collect())
     }
 }

--- a/src/expression/minimize.rs
+++ b/src/expression/minimize.rs
@@ -109,10 +109,10 @@ impl super::Expression {
                     .into_iter()
                     .enumerate()
                     .filter_map(|(ind, lic)| {
-                        if mask & (1 << ind) != 0 {
-                            Some(lic.into_req())
-                        } else {
+                        if mask & (1 << ind) == 0 {
                             None
+                        } else {
+                            Some(lic.into_req())
                         }
                     })
                     .collect());

--- a/src/expression/parser.rs
+++ b/src/expression/parser.rs
@@ -37,7 +37,6 @@ impl Expression {
     /// ).unwrap();
     /// ```
     pub fn parse_mode(original: &str, mode: ParseMode) -> Result<Self, ParseError<'_>> {
-        let lexer = Lexer::new_mode(original, mode);
         // Operator precedence in SPDX 2.1
         // +
         // WITH
@@ -57,6 +56,7 @@ impl Expression {
             span: std::ops::Range<usize>,
         }
 
+        let lexer = Lexer::new_mode(original, mode);
         let mut op_stack = SmallVec::<[OpAndSpan; 3]>::new();
         let mut expr_queue = SmallVec::<[ExprNode; 5]>::new();
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -166,6 +166,12 @@ impl<'a> Iterator for Lexer<'a> {
     type Item = Result<LexerToken<'a>, ParseError<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        #[allow(clippy::unnecessary_wraps)]
+        fn ok_token<'a>(token: Token<'_>) -> Option<Result<(Token<'_>, usize), ParseError<'a>>> {
+            let len = token.len();
+            Some(Ok((token, len)))
+        }
+
         // Jump over any whitespace, updating `self.inner` and `self.offset` appropriately
         let non_whitespace_index = match self.inner.find(|c: char| !c.is_whitespace()) {
             Some(idx) => idx,
@@ -173,12 +179,6 @@ impl<'a> Iterator for Lexer<'a> {
         };
         self.inner = &self.inner[non_whitespace_index..];
         self.offset += non_whitespace_index;
-
-        #[allow(clippy::unnecessary_wraps)]
-        fn ok_token<'a>(token: Token<'_>) -> Option<Result<(Token<'_>, usize), ParseError<'a>>> {
-            let len = token.len();
-            Some(Ok((token, len)))
-        }
 
         match self.inner.chars().next() {
             None => None,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -183,14 +183,14 @@ impl<'a> Iterator for Lexer<'a> {
             // From SPDX 2.1 spec
             // There MUST NOT be whitespace between a license-id and any following "+".
             Some('+') => {
-                if non_whitespace_index != 0 {
+                if non_whitespace_index == 0 {
+                    ok_token(Token::Plus)
+                } else {
                     Some(Err(ParseError {
                         original: self.original,
                         span: self.offset - non_whitespace_index..self.offset,
                         reason: Reason::SeparatedPlus,
                     }))
-                } else {
-                    ok_token(Token::Plus)
                 }
             }
             Some('(') => ok_token(Token::OpenParen),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -90,6 +90,7 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     /// Creates a Lexer over a license expression
+    #[must_use]
     pub fn new(text: &'a str) -> Self {
         Self {
             inner: text,
@@ -103,6 +104,7 @@ impl<'a> Lexer<'a> {
     ///
     /// With `ParseMode::Lax` it allows non-conforming syntax
     /// used in crates-io crates.
+    #[must_use]
     pub fn new_mode(text: &'a str, mode: ParseMode) -> Self {
         Self {
             inner: text,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ impl LicenseId {
     /// assert!(spdx::license_id("GPL-2.0-only").unwrap().is_fsf_free_libre());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_fsf_free_libre(self) -> bool {
         self.flags & IS_FSF_LIBRE != 0
     }
@@ -150,6 +151,7 @@ impl LicenseId {
     /// assert!(spdx::license_id("MIT").unwrap().is_osi_approved());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_osi_approved(self) -> bool {
         self.flags & IS_OSI_APPROVED != 0
     }
@@ -160,6 +162,7 @@ impl LicenseId {
     /// assert!(spdx::license_id("wxWindows").unwrap().is_deprecated());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_deprecated(self) -> bool {
         self.flags & IS_DEPRECATED != 0
     }
@@ -170,6 +173,7 @@ impl LicenseId {
     /// assert!(spdx::license_id("LGPL-3.0-or-later").unwrap().is_copyleft());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_copyleft(self) -> bool {
         self.flags & IS_COPYLEFT != 0
     }
@@ -181,6 +185,7 @@ impl LicenseId {
     /// assert!(spdx::license_id("AGPL-3.0-only").unwrap().is_gnu());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_gnu(self) -> bool {
         self.flags & IS_GNU != 0
     }
@@ -245,6 +250,7 @@ impl ExceptionId {
     /// assert!(spdx::exception_id("Nokia-Qt-exception-1.1").unwrap().is_deprecated());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_deprecated(self) -> bool {
         self.flags & IS_DEPRECATED != 0
     }
@@ -351,6 +357,7 @@ pub enum LicenseItem {
 impl LicenseItem {
     /// Returns the license identifier, if it is a recognized SPDX license and not
     /// a license referencer
+    #[must_use]
     pub fn id(&self) -> Option<LicenseId> {
         match self {
             Self::Spdx { id, .. } => Some(*id),
@@ -423,6 +430,7 @@ impl PartialEq for LicenseItem {
     }
 }
 
+#[must_use]
 impl fmt::Display for LicenseItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
@@ -459,6 +467,7 @@ impl fmt::Display for LicenseItem {
 /// assert!(spdx::license_id("BitTorrent-1.1+").is_some());
 /// ```
 #[inline]
+#[must_use]
 pub fn license_id(name: &str) -> Option<LicenseId> {
     let name = name.trim_end_matches('+');
     identifiers::LICENSES
@@ -486,6 +495,7 @@ pub fn license_id(name: &str) -> Option<LicenseId> {
 /// assert!(spdx::imprecise_license_id("simplified bsd license").unwrap().0 == spdx::license_id("BSD-2-Clause").unwrap());
 /// ```
 #[inline]
+#[must_use]
 pub fn imprecise_license_id(name: &str) -> Option<(LicenseId, usize)> {
     for (prefix, correct_name) in identifiers::IMPRECISE_NAMES {
         if let Some(name_prefix) = name.as_bytes().get(0..prefix.len()) {
@@ -507,6 +517,7 @@ pub fn imprecise_license_id(name: &str) -> Option<(LicenseId, usize)> {
 /// assert!(spdx::exception_id("LLVM-exception").is_some());
 /// ```
 #[inline]
+#[must_use]
 pub fn exception_id(name: &str) -> Option<ExceptionId> {
     identifiers::EXCEPTIONS
         .binary_search_by(|exc| exc.0.cmp(name))
@@ -524,6 +535,7 @@ pub fn exception_id(name: &str) -> Option<ExceptionId> {
 /// assert_eq!(spdx::license_version(), "3.14");
 /// ```
 #[inline]
+#[must_use]
 pub fn license_version() -> &'static str {
     identifiers::VERSION
 }

--- a/src/licensee.rs
+++ b/src/licensee.rs
@@ -194,7 +194,7 @@ impl Licensee {
             (LicenseItem::Spdx { id: a, .. }, LicenseItem::Spdx { id: b, or_later }) => {
                 if a.index != b.index {
                     if *or_later {
-                        let (a_name, agfdl_invariants) = if a.name.starts_with("GFDL") {
+                        let (a_name, a_gfdl_invariants) = if a.name.starts_with("GFDL") {
                             a.name
                                 .strip_suffix("-invariants")
                                 .map_or((a.name, false), |name| (name, true))
@@ -202,7 +202,7 @@ impl Licensee {
                             (a.name, false)
                         };
 
-                        let (b_name, bgfdl_invariants) = if b.name.starts_with("GFDL") {
+                        let (b_name, b_gfdl_invariants) = if b.name.starts_with("GFDL") {
                             b.name
                                 .strip_suffix("-invariants")
                                 .map_or((b.name, false), |name| (name, true))
@@ -210,7 +210,7 @@ impl Licensee {
                             (b.name, false)
                         };
 
-                        if agfdl_invariants != bgfdl_invariants {
+                        if a_gfdl_invariants != b_gfdl_invariants {
                             return false;
                         }
 
@@ -218,12 +218,12 @@ impl Licensee {
                         // so chop that off and ensure the base strings match, and if so,
                         // just a do a lexical compare, if this "allowed license" is >,
                         // then we satisfed the license requirement
-                        let atest_name =
+                        let a_test_name =
                             &a_name[..a_name.rfind('-').unwrap_or_else(|| a_name.len())];
-                        let btest_name =
+                        let b_test_name =
                             &b_name[..b_name.rfind('-').unwrap_or_else(|| b_name.len())];
 
-                        if atest_name != btest_name || a_name < b_name {
+                        if a_test_name != b_test_name || a_name < b_name {
                             return false;
                         }
                     } else {
@@ -233,15 +233,15 @@ impl Licensee {
             }
             (
                 LicenseItem::Other {
-                    doc_ref: doca,
-                    lic_ref: lica,
+                    doc_ref: doc_a,
+                    lic_ref: lic_a,
                 },
                 LicenseItem::Other {
-                    doc_ref: docb,
-                    lic_ref: licb,
+                    doc_ref: doc_b,
+                    lic_ref: lic_b,
                 },
             ) => {
-                if doca != docb || lica != licb {
+                if doc_a != doc_b || lic_a != lic_b {
                     return false;
                 }
             }

--- a/src/licensee.rs
+++ b/src/licensee.rs
@@ -29,6 +29,7 @@ impl Licensee {
     /// Creates a licensee from its component parts. Note that use of SPDX's
     /// `or_later` is completely ignored for licensees as it only applies
     /// to the license holder(s), not the licensee
+    #[must_use]
     pub fn new(license: LicenseItem, exception: Option<ExceptionId>) -> Self {
         if let LicenseItem::Spdx { or_later, .. } = &license {
             debug_assert!(!or_later);
@@ -189,6 +190,7 @@ impl Licensee {
     ///     exception: spdx::exception_id("LLVM-exception"),
     /// }));
     /// ```
+    #[must_use]
     pub fn satisfies(&self, req: &LicenseReq) -> bool {
         match (&self.inner.license, &req.license) {
             (LicenseItem::Spdx { id: a, .. }, LicenseItem::Spdx { id: b, or_later }) => {
@@ -251,6 +253,7 @@ impl Licensee {
         req.exception == self.inner.exception
     }
 
+    #[must_use]
     pub fn into_req(self) -> LicenseReq {
         self.inner
     }


### PR DESCRIPTION
Almost all of these changes were suggested by:

```
cargo clippy --release -- --deny clippy::pedantic
```

Exceptions:

* Moves expression.rs to expression/mod.rs
* Moves text.rs to text/mod.rs