### PR TITLE
ParseMode: Convert from enum to configurable struct

### DIFF
--- a/src/expression/minimize.rs
+++ b/src/expression/minimize.rs
@@ -1,3 +1,4 @@
+use super::Expression;
 use crate::{LicenseReq, Licensee};
 use std::fmt;
 
@@ -36,21 +37,22 @@ impl std::error::Error for MinimizeError {
     }
 }
 
-impl super::Expression {
+impl Expression {
     /// Given a set of [`Licensee`]s, attempts to find the minimum number that
-    /// satisfy this [`Expression`]. The list of licensees should be given in
-    /// priority order, eg, if you wish to accept the `Apache-2.0` license if
-    /// it is available and the `MIT` if not, putting `Apache-2.0` before `MIT`
-    /// will cause the ubiquitous `Apache-2.0 OR MIT` expression to minimize to
-    /// just `Apache-2.0` as only only 1 of the licenses is required, and the
-    /// `Apache-2.0` has priority.
+    /// satisfy this [`Expression`].
+    ///
+    /// The list of licensees should be given in priority order, eg, if you wish
+    /// to accept the `Apache-2.0` license if it is available, and the `MIT` if
+    /// not, putting `Apache-2.0` before `MIT` will cause the ubiquitous
+    /// `Apache-2.0 OR MIT` expression to minimize to just `Apache-2.0` as only
+    /// 1 of the licenses is required, and `Apache-2.0` has priority.
     ///
     /// # Errors
     ///
     /// This method will fail if more than 64 unique licensees are satisfied by
-    /// this expression, but such a case is unlikely to say the least in a real
-    /// world scenario. The list of licensees must also actually satisfy this
-    /// expression, otherwise it can't be minimized.
+    /// this expression, but such a case is unlikely in a real world scenario.
+    /// The list of licensees must also actually satisfy this expression,
+    /// otherwise it can't be minimized.
     ///
     /// # Example
     ///

--- a/src/expression/parser.rs
+++ b/src/expression/parser.rs
@@ -23,7 +23,7 @@ impl Expression {
     /// spdx::Expression::parse("MIT OR Apache-2.0 WITH LLVM-exception").unwrap();
     /// ```
     pub fn parse(original: &str) -> Result<Self, ParseError> {
-        Self::parse_mode(original, ParseMode::Strict)
+        Self::parse_mode(original, ParseMode::STRICT)
     }
 
     /// Parses an expression with the specified `ParseMode`. With
@@ -33,7 +33,7 @@ impl Expression {
     /// ```
     /// spdx::Expression::parse_mode(
     ///     "mit/Apache-2.0 WITH LLVM-exception",
-    ///     spdx::ParseMode::Lax
+    ///     spdx::ParseMode::LAX
     /// ).unwrap();
     /// ```
     pub fn parse_mode(original: &str, mode: ParseMode) -> Result<Self, ParseError> {
@@ -130,7 +130,7 @@ impl Expression {
                             ..
                         }) => {
                             // Handle GNU licenses differently, as they should *NOT* be used with the `+`
-                            if mode == ParseMode::Strict && id.is_gnu() {
+                            if !mode.allow_postfix_plus_on_gpl && id.is_gnu() {
                                 return Err(ParseError {
                                     original: original.to_owned(),
                                     span: lt.span,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -3,17 +3,33 @@ use crate::{
     ExceptionId, LicenseId,
 };
 
-/// Available modes when parsing SPDX expressions
+/// Parsing configuration for SPDX expression
 #[derive(Default, Copy, Clone)]
 pub struct ParseMode {
+    /// The `AND`, `OR`, and `WITH` operators are required to be uppercase in
+    /// the SPDX spec, but enabling this option allows them to be lowercased
     pub allow_lower_case_operators: bool,
+    /// Allows the use of `/` as a synonym for the `OR` operator. This also
+    /// allows for not having whitespace between the `/` and the terms on either
+    /// side
     pub allow_slash_as_or_operator: bool,
+    /// Allows some invalid/imprecise identifiers as synonyms for an actual
+    /// license identifier. See [`IMPRECISE_NAMES`](crate::identifiers::IMPRECISE_NAMES)
+    /// for a list of the current synonyms. Note that this list is not
+    /// comprehensive but can be expanded upon when invalid identifiers are
+    /// found in the wild.
     pub allow_imprecise_license_names: bool,
+    /// The various GPL licenses diverge from every other license in the SPDX
+    /// license list by having an `-or-later` variant that used as a suffix on a
+    /// base license (eg. `GPL-3.0-or-later`) rather than the canonical `GPL-3.0+`.
+    /// This option just allows GPL licenses to be treated similarly to all of
+    /// the other SPDX licenses.
     pub allow_postfix_plus_on_gpl: bool,
 }
 
 impl ParseMode {
-    /// Strict SPDX parsing.
+    /// Strict, specification compliant SPDX parsing.
+    ///
     /// 1. Only license identifiers in the SPDX license list, or
     /// Document/LicenseRef, are allowed. The license identifiers are also
     /// case-sensitive.
@@ -26,10 +42,11 @@ impl ParseMode {
     };
 
     /// Allow non-conforming syntax for crates-io compatibility
+    ///
     /// 1. Additional, invalid, identifiers are accepted and mapped to a correct
-    /// SPDX license identifier. See
-    /// [identifiers::IMPRECISE_NAMES](../identifiers/constant.IMPRECISE_NAMES.html)
-    /// for the list of additionally accepted identifiers and the license they
+    /// SPDX license identifier.
+    /// See [`IMPRECISE_NAMES`](crate::identifiers::IMPRECISE_NAMES) for the
+    /// list of additionally accepted identifiers and the license they
     /// correspond to.
     /// 1. `/` can by used as a synonym for `OR`, and doesn't need to be
     /// separated by whitespace from the terms it combines

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -10,13 +10,13 @@ macro_rules! exact {
 
 macro_rules! check {
     ($le:expr => [$($logical_expr:expr => $is_allowed:expr),+$(,)?]) => {
-        check_mode!(spdx::ParseMode::Strict, $le => [$($logical_expr => $is_allowed),+])
+        check_mode!(spdx::ParseMode::STRICT, $le => [$($logical_expr => $is_allowed),+])
     };
 }
 
 macro_rules! check_lax {
     ($le:expr => [$($logical_expr:expr => $is_allowed:expr),+$(,)?]) => {
-        check_mode!(spdx::ParseMode::Lax, $le => [$($logical_expr => $is_allowed),+])
+        check_mode!(spdx::ParseMode::LAX, $le => [$($logical_expr => $is_allowed),+])
     };
 }
 
@@ -191,7 +191,7 @@ fn gpl_or_later_plus_strict() {
 
 #[test]
 fn gpl_or_later_plus_lax() {
-    spdx::Expression::parse_mode("GPL-2.0+", spdx::ParseMode::Lax).unwrap();
+    spdx::Expression::parse_mode("GPL-2.0+", spdx::ParseMode::LAX).unwrap();
 }
 
 #[test]

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -120,7 +120,7 @@ fn fails_with_slash() {
 
 #[test]
 fn lax_takes_slash() {
-    let lexed: Vec<_> = Lexer::new_mode("MIT/Apache", spdx::ParseMode::Lax)
+    let lexed: Vec<_> = Lexer::new_mode("MIT/Apache", spdx::ParseMode::LAX)
         .map(|r| r.map(|lt| lt.token).unwrap())
         .collect();
     assert_eq!(
@@ -131,7 +131,7 @@ fn lax_takes_slash() {
 
 #[test]
 fn fixes_license_names() {
-    let lexed: Vec<_> = Lexer::new_mode("gpl v2 / bsd 2-clause", spdx::ParseMode::Lax)
+    let lexed: Vec<_> = Lexer::new_mode("gpl v2 / bsd 2-clause", spdx::ParseMode::LAX)
         .map(|r| r.map(|lt| lt.token).unwrap())
         .collect();
     assert_eq!(


### PR DESCRIPTION
This allows users to only opt-in to some of the laxness, if necessary.

This should probably be considered a breaking change since the type of the public `ParseMode` has changed.