### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Feature requests will be tagged as `enhancement` and their status will be update
 
 ### Bugs
 
-When reporting a bug or unexpected behaviour in a project, make sure your issue descibes steps to reproduce the behaviour, including the platform you were using, what steps you took, and any error messages.
+When reporting a bug or unexpected behaviour in a project, make sure your issue describes steps to reproduce the behaviour, including the platform you were using, what steps you took, and any error messages.
 
 Reproducible bugs will be tagged as `bug` and their status will be updated in the comments of the issue.
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -154,7 +154,7 @@ impl Expression {
     }
 
     /// Just as with evaluate, the license expression is evaluated to see if
-    /// enough license requirements in the expresssion are met for the evaluation
+    /// enough license requirements in the expression are met for the evaluation
     /// to succeed, except this method also keeps track of each failed requirement
     /// and returns them, allowing for more detailed error reporting about precisely
     /// what terms in the expression caused the overall failure

--- a/src/identifiers.rs
+++ b/src/identifiers.rs
@@ -1757,7 +1757,7 @@ pub const LICENSES: &[(&str, &str, u8)] = &[
     ),
 ];
 
-/// Pairs an invalid license identifier with its valide SPDX license identifier.
+/// Pairs an invalid license identifier with its valid SPDX license identifier.
 /// These invalid identifiers are only allowed when using `Lax` parsing.
 pub const IMPRECISE_NAMES: &[(&str, &str)] = &[
     ("agplv3", "AGPL-3.0"),

--- a/update/src/imprecise.rs
+++ b/update/src/imprecise.rs
@@ -1,4 +1,4 @@
-/// Pairs an invalid license identifier with its valide SPDX license identifier.
+/// Pairs an invalid license identifier with its valid SPDX license identifier.
 /// These invalid identifiers are only allowed when using `Lax` parsing.
 pub const IMPRECISE_NAMES: &[(&str, &str)] = &[
     ("agplv3", "AGPL-3.0"),


### PR DESCRIPTION
Found via `codespell -S ./src/text/licenses -L crate,clos`