### PR TITLE
Implement FromStr for Expression and Licensee

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,7 +1,7 @@
 mod minimize;
 mod parser;
 
-use crate::LicenseReq;
+use crate::{error::ParseError, LicenseReq};
 pub use minimize::MinimizeError;
 use smallvec::SmallVec;
 use std::fmt;
@@ -228,6 +228,13 @@ impl fmt::Debug for Expression {
 impl fmt::Display for Expression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.original)
+    }
+}
+
+impl std::str::FromStr for Expression {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
     }
 }
 

--- a/src/licensee.rs
+++ b/src/licensee.rs
@@ -25,6 +25,14 @@ impl fmt::Display for Licensee {
     }
 }
 
+impl std::str::FromStr for Licensee {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
 impl Licensee {
     /// Creates a licensee from its component parts. Note that use of SPDX's
     /// `or_later` is completely ignored for licensees as it only applies


### PR DESCRIPTION
Their `from_str` implementations forward to their `parse` methods. This allows the types to more easily integrate into other parts of the Rust ecosystem, like clap and `serde_with::DeserializeFromStr`.