### PR TITLE
feat!: support AdditionRef in SPDX v3

### DIFF
--- a/tests/check.rs
+++ b/tests/check.rs
@@ -254,7 +254,7 @@ fn gpl_pedantic() {
                     id: spdx::license_id(col).unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             };
 
             exp.push_str(if *passes { "+" } else { "-" });
@@ -391,7 +391,7 @@ fn minimizes_vanilla() {
                 id: spdx::license_id("Apache-2.0").unwrap(),
                 or_later: false,
             },
-            exception: None,
+            addition: None,
         }]
     );
 
@@ -407,7 +407,7 @@ fn minimizes_vanilla() {
                 id: spdx::license_id("MIT").unwrap(),
                 or_later: false,
             },
-            exception: None,
+            addition: None,
         }]
     );
 }
@@ -430,21 +430,21 @@ fn handles_unminimizable() {
                     id: spdx::license_id("ISC").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
             spdx::LicenseReq {
                 license: LicenseItem::Spdx {
                     id: spdx::license_id("OpenSSL").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
             spdx::LicenseReq {
                 license: LicenseItem::Spdx {
                     id: spdx::license_id("MIT").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             }
         ]
     );
@@ -468,21 +468,21 @@ fn handles_complicated() {
                     id: spdx::license_id("Apache-2.0").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
             spdx::LicenseReq {
                 license: LicenseItem::Spdx {
                     id: spdx::license_id("ISC").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
             spdx::LicenseReq {
                 license: LicenseItem::Spdx {
                     id: spdx::license_id("OpenSSL").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
         ]
     );
@@ -502,21 +502,21 @@ fn handles_complicated() {
                     id: spdx::license_id("MIT").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
             spdx::LicenseReq {
                 license: LicenseItem::Spdx {
                     id: spdx::license_id("ISC").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
             spdx::LicenseReq {
                 license: LicenseItem::Spdx {
                     id: spdx::license_id("OpenSSL").unwrap(),
                     or_later: false,
                 },
-                exception: None,
+                addition: None,
             },
         ]
     );

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -25,7 +25,7 @@ macro_rules! exc_tok {
 
 #[test]
 fn lexes_all_the_things() {
-    let text = "MIT+ OR () Apache-2.0 WITH AND LicenseRef-World Classpath-exception-2.0 DocumentRef-Test:LicenseRef-Hello";
+    let text = "MIT+ OR () Apache-2.0 WITH AND LicenseRef-World Classpath-exception-2.0 DocumentRef-Test:LicenseRef-Hello AdditionRef-add1 DocumentRef-add-doc:AdditionRef-add2";
 
     test_lex!(
         text,
@@ -46,6 +46,14 @@ fn lexes_all_the_things() {
             Token::LicenseRef {
                 doc_ref: Some("Test"),
                 lic_ref: "Hello",
+            },
+            Token::AdditionRef {
+                doc_ref: None,
+                add_ref: "add1",
+            },
+            Token::AdditionRef {
+                doc_ref: Some("add-doc"),
+                add_ref: "add2",
             },
         ]
     );

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -71,17 +71,17 @@ fn fails_unbalanced_parens() {
 
 #[test]
 fn fails_bad_exception() {
-    err!("Apache-2.0 WITH WITH LLVM-exception OR Apache-2.0" => &["<exception>"]; 16..20);
-    err!("Apache-2.0 WITH WITH LLVM-exception" => &["<exception>"]; 16..20);
+    err!("Apache-2.0 WITH WITH LLVM-exception OR Apache-2.0" => &["<addition>"]; 16..20);
+    err!("Apache-2.0 WITH WITH LLVM-exception" => &["<addition>"]; 16..20);
     err!("(Apache-2.0) WITH LLVM-exception" => &["AND", "OR"]; 13..17);
     err!("Apache-2.0 (WITH LLVM-exception)" => &["AND", "OR", "WITH", ")", "+"]; 11..12);
-    err!("(Apache-2.0 WITH) LLVM-exception" => &["<exception>"]; 16..17);
-    err!("(Apache-2.0 WITH)+ LLVM-exception" => &["<exception>"]; 16..17);
-    err!("Apache-2.0 WITH MIT" => &["<exception>"]; 16..19);
-    err!("Apache-2.0 WITH WITH MIT" => &["<exception>"]; 16..20);
+    err!("(Apache-2.0 WITH) LLVM-exception" => &["<addition>"]; 16..17);
+    err!("(Apache-2.0 WITH)+ LLVM-exception" => &["<addition>"]; 16..17);
+    err!("Apache-2.0 WITH MIT" => &["<addition>"]; 16..19);
+    err!("Apache-2.0 WITH WITH MIT" => &["<addition>"]; 16..20);
     err!("Apache-2.0 AND WITH MIT" => &["<license>", "("]; 15..19);
-    err!("Apache-2.0 WITH AND MIT" => &["<exception>"]; 16..19);
-    err!("Apache-2.0 WITH" => &["<exception>"]; 15..15);
+    err!("Apache-2.0 WITH AND MIT" => &["<addition>"]; 16..19);
+    err!("Apache-2.0 WITH" => &["<addition>"]; 15..15);
 }
 
 #[test]
@@ -97,8 +97,9 @@ fn fails_bad_plus() {
     err!("LicenseRef-Nope+" => &["AND", "OR", "WITH", ")"]; 15..16);
     err!("LAL-1.2 AND+" => &["<license>", "("]; 11..12);
     err!("LAL-1.2 OR +" => SeparatedPlus @ 10..11);
-    err!("LAL-1.2 WITH+ LLVM-exception" => &["<exception>"]; 12..13);
+    err!("LAL-1.2 WITH+ LLVM-exception" => &["<addition>"]; 12..13);
     err!("LAL-1.2 WITH LLVM-exception+" => &["AND", "OR", ")"]; 27..28);
+    err!("LAL-1.2 WITH AdditionRef-myexc+" => &["AND", "OR", ")"]; 30..31);
 }
 
 #[test]
@@ -111,7 +112,7 @@ fn fails_bad_ops() {
     err!("(MIT-advertising AND) MIT" => &["<license>", "("]; 20..21);
     err!("MIT-advertising (AND MIT)" => &["AND", "OR", "WITH", ")", "+"]; 16..17);
     err!("OR MIT-advertising" => &["<license>", "("]; 0..2);
-    err!("MIT-advertising WITH AND" => &["<exception>"]; 21..24);
+    err!("MIT-advertising WITH AND" => &["<addition>"]; 21..24);
 }
 
 #[test]
@@ -136,9 +137,13 @@ fn validates_canonical() {
 #[test]
 fn validates_single_with_exception() {
     let with_exception = "Apache-2.0 WITH LLVM-exception";
+    let addition_ref = "MPL-2.0 WITH AdditionRef-Embark-Exception";
+    let doc_addition_ref = "MIT WITH DocumentRef-Embark:AdditionRef-Embark-Exception";
 
     test_validate!(ok [
         with_exception => [with_exception],
+        addition_ref => [addition_ref],
+        doc_addition_ref => [doc_addition_ref],
     ]);
 }
 


### PR DESCRIPTION
Resolves #68 

This adds support of `<addition-expression>` in SPDX v3 specification:

```
addition-ref = [%s"DocumentRef-"(idstring)":"]%s"AdditionRef-"(idstring)
addition-expression = license-exception-id / addition-ref
```

See https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/

BREAKING: SemVer major breakage with new enum variants and struct fields.

---

The motivation of this is <https://github.com/rust-lang/cargo/pull/15847> btw



